### PR TITLE
Fix retry upon 401

### DIFF
--- a/src/pyrouter/router_client.py
+++ b/src/pyrouter/router_client.py
@@ -75,8 +75,9 @@ class RouterClient(object):
                 return unquote_dict(resp_json)
         elif response.status_code == 401 and will_retry_upon_401:
             self.authenticate()
-            self._post(payload, will_retry_upon_401=False,
-                       raise_on_error=raise_on_error)
+            return self._post(
+                payload, will_retry_upon_401=False,
+                raise_on_error=raise_on_error)
 
         if raise_on_error:
             try:


### PR DESCRIPTION
After `stok` became expired, the client would throw `RouterAPIError: UNAUTH` on the first call, and would only succeed on the second call, even if `will_retry_upon_401=True` (the default).

After this patch, the client will ignore the first 401, and returns the retried response (after authenticate) on the very first call.